### PR TITLE
DBスキーマの定義と実装のズレを修正

### DIFF
--- a/packages/backend/prisma/migrations/20240401101602_fix_dons_table_changed_vegetable_column_to_yasai_and_garlic_to_ninniku_and_set_defaults_on_created_at_and_updated_at_columns/migration.sql
+++ b/packages/backend/prisma/migrations/20240401101602_fix_dons_table_changed_vegetable_column_to_yasai_and_garlic_to_ninniku_and_set_defaults_on_created_at_and_updated_at_columns/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `garlic` on the `dons` table. All the data in the column will be lost.
+  - You are about to drop the column `vegetable` on the `dons` table. All the data in the column will be lost.
+  - Added the required column `ninniku` to the `dons` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `yasai` to the `dons` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "dons" DROP COLUMN "garlic",
+DROP COLUMN "vegetable",
+ADD COLUMN     "ninniku" INTEGER NOT NULL,
+ADD COLUMN     "yasai" INTEGER NOT NULL,
+ALTER COLUMN "created_at" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "orders" ALTER COLUMN "created_at" SET DEFAULT CURRENT_TIMESTAMP;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -28,13 +28,13 @@ model dons {
   size_id      Int
   order_id     BigInt
   status       Int
-  vegetable    Int
-  garlic       Int
+  yasai        Int
+  ninniku      Int
   karame       Int
   abura        Int
   sns_followed Boolean? @default(false)
-  created_at   DateTime
-  updated_at   DateTime
+  created_at   DateTime @default(now())
+  updated_at   DateTime @updatedAt
   sizes        sizes    @relation(fields: [size_id], references: [id])
   orders       orders   @relation(fields: [order_id], references: [id])
   adding       adding[]
@@ -42,7 +42,7 @@ model dons {
 
 model orders {
   id         BigInt   @id @default(autoincrement())
-  created_at DateTime
+  created_at DateTime @default(now())
   call_num   Int
   dons       dons[]
 }

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -14,11 +14,11 @@ datasource db {
 }
 
 model adding {
-  don_id      BigInt 
-  topping_id  Int
-  amount      Int
-  dons        dons     @relation(fields: [don_id], references: [id])
-  toppings    toppings @relation(fields: [topping_id], references: [id])
+  don_id     BigInt
+  topping_id Int
+  amount     Int
+  dons       dons     @relation(fields: [don_id], references: [id])
+  toppings   toppings @relation(fields: [topping_id], references: [id])
 
   @@id([don_id, topping_id])
 }
@@ -57,24 +57,23 @@ model sizes {
 model size_prices {
   id      Int      @id @default(autoincrement())
   size_id Int
-  price   Int  
+  price   Int
   since   DateTime
   sizes   sizes    @relation(fields: [size_id], references: [id])
 }
 
 model toppings {
-  id              Int               @id @default(autoincrement())
-  label           String            @db.VarChar()
-  available       Boolean?          @default(true)
-  adding          adding[]
-  topping_prices  topping_prices[]
+  id             Int              @id @default(autoincrement())
+  label          String           @db.VarChar()
+  available      Boolean?         @default(true)
+  adding         adding[]
+  topping_prices topping_prices[]
 }
 
 model topping_prices {
   id         Int      @id @default(autoincrement())
-  topping_id Int 
-  price      Int 
+  topping_id Int
+  price      Int
   since      DateTime
   toppings   toppings @relation(fields: [topping_id], references: [id])
 }
-


### PR DESCRIPTION
## Overview
DBスキーマについて，[notionでの定義](https://www.notion.so/DB-4d6845cc5574443d86a8c9442d2f655b)や #18 でのAPI定義と，`schema.prisma`での定義で若干の齟齬があったためその修正が主な内容です．
他にも，フォーマッタによるリファクタリングやカラム制約の変更を含みます．
**既存のスキーマに変更を加えるPRです．**

## Changes
- `dons`テーブルの`vegetable`カラム，`garlic`カラムの名前を`yasai`および`ninniku`に変更
  - notionでの定義やAPI定義に合わせました
- `created_at`や`updated_at`にデフォルト値を設定
  - アプリケーション側で実装するより手っ取り早いと思ったので設定しました
- フォーマッタによるフォーマット
- 上記の変更を反映するマイグレーションを追加

## 影響範囲
DBスキーマやPrisma Clientを使う機能・
