### PR TITLE
fix(backend): Revert to CommonJS from ESModule

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -2,7 +2,6 @@
   "name": "backend",
   "version": "0.1.0",
   "description": "",
-  "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "start": "node ./built/index.js",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,10 +1,7 @@
 import express from "express";
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
- 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import { fileURLToPath } from "./middlewares/errorHandler";
 
 const app = express();
 const port = 52600;
@@ -20,7 +17,9 @@ const filenames = fs.readdirSync(path.join(__dirname, 'routes'));
 // ファイル名ごとにrouteを動的インポート
 for (const filename of filenames ) {
   const name = filename.replace('.js', '');
-  const route = await import(`./routes/${name}.js`);
+  const route_path = `${__dirname}/routes/${name}.js`;
+  const route = require(route_path);
+
   app.use(`/api/${name}`, route.default);
 }
 

--- a/packages/backend/src/routes/dons.ts
+++ b/packages/backend/src/routes/dons.ts
@@ -1,5 +1,5 @@
 import express, { Request } from 'express';
-import prisma from '@/lib/prismaClient.js';
+import prisma from '@/lib/prismaClient';
 
 interface Topping {
   id: number,

--- a/packages/backend/src/routes/order.ts
+++ b/packages/backend/src/routes/order.ts
@@ -1,5 +1,5 @@
-import prisma from '@/lib/prismaClient.js';
-import { bigint2number } from '@/utils/typeConverters.js';
+import prisma from '@/lib/prismaClient';
+import { bigint2number } from '@/utils/typeConverters';
 import express from 'express';
 import util from 'util';
 

--- a/packages/backend/src/routes/toppings.ts
+++ b/packages/backend/src/routes/toppings.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import prisma from '@/lib/prismaClient.js';
+import prisma from '@/lib/prismaClient';
 
 const router = express.Router();
 

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -3,12 +3,12 @@
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
     /* Language and Environment */
-    "target": "ESNext", 
-
+    "target": "ES2020",
+    
     /* Modules */
-    "module": "ESNext",
+    "module": "Node16",
     "rootDir": "./src",
-    "moduleResolution": "Node", 
+    "moduleResolution": "Node16",
     "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*", "./dist/*"]


### PR DESCRIPTION
tsconfig.json の target を ESModule から CommonJS に変更しました．

これにより，パッケージをインポートする際に拡張子をつける必要がなくなりました．