### PR TITLE
dons/:idで発生するエラーの対応

### DIFF
--- a/packages/backend/src/routes/dons.ts
+++ b/packages/backend/src/routes/dons.ts
@@ -111,8 +111,6 @@ router.get('/:id', asyncWrapper(async (req, res, next) => {
       },
   });
 
-  console.log(don);
-
   //そのIDのDonがない場合，エラーを返す．
   if(!don){
       throw ApiError.internalProblems();

--- a/packages/backend/src/routes/dons.ts
+++ b/packages/backend/src/routes/dons.ts
@@ -111,13 +111,21 @@ router.get('/:id', asyncWrapper(async (req, res, next) => {
       },
   });
 
+  console.log(don);
+
   //そのIDのDonがない場合，エラーを返す．
   if(!don){
       throw ApiError.internalProblems();
   }
 
+  const resDon = {
+    ...don,
+    id: don.id.toString(),
+    order_id: don.order_id.toString()
+  };
+
   //とりあえずJSONで送る
-  res.status(200).json(don);
+  res.status(200).json(resDon);
 
 }));
 


### PR DESCRIPTION
開発用データを入れてテストしたところ，以下のようなエラーが発生しました．

## 発生したエラー
```
TypeError: Do not know how to serialize a BigInt
    at JSON.stringify (<anonymous>)
    at stringify (/workspaces/Kojirer/node_modules/express/lib/response.js:1159:12)
    at ServerResponse.json (/workspaces/Kojirer/node_modules/express/lib/response.js:272:14)
    at /workspaces/Kojirer/packages/backend/built/routes/dons.js:95:21
```

bigintをjsonでresponseするとエラーが発生してしまうので，bigintをstringに変換してレスポンスするように修正しました．
この修正により，開発用データで正常にデータが取得できることを確認しました．

donsテーブルの`id``order_id`がbigintを用いているので，この２つをstringとして返却するように修正しております．