### PR TITLE
`put /dons/id`追加 & `get /dons`の修正

### DIFF
--- a/packages/api/dist/schema.d.mts
+++ b/packages/api/dist/schema.d.mts
@@ -1,4 +1,40 @@
 interface paths {
+    "/dons": {
+        parameters: {
+            query?: never | null;
+            header?: never | null;
+            path?: never | null;
+            cookie?: never | null;
+        };
+        /** @description 全ての丼を取得 */
+        get: {
+            parameters: {
+                query?: never | null;
+                header?: never | null;
+                path?: never | null;
+                cookie?: never | null;
+            };
+            requestBody?: never | null;
+            responses: {
+                /** @description 成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Don"][];
+                    };
+                };
+            };
+        };
+        put?: never | null;
+        post?: never | null;
+        delete?: never | null;
+        options?: never | null;
+        head?: never | null;
+        patch?: never | null;
+        trace?: never | null;
+    };
     "/dons/{id}": {
         parameters: {
             query?: never | null;
@@ -43,7 +79,7 @@ interface paths {
                 content: {
                     "application/json": {
                         /** Format: int32 */
-                        status?: number | null;
+                        status: number;
                     };
                 };
             };

--- a/packages/api/dist/schema.d.ts
+++ b/packages/api/dist/schema.d.ts
@@ -1,4 +1,40 @@
 interface paths {
+    "/dons": {
+        parameters: {
+            query?: never | null;
+            header?: never | null;
+            path?: never | null;
+            cookie?: never | null;
+        };
+        /** @description 全ての丼を取得 */
+        get: {
+            parameters: {
+                query?: never | null;
+                header?: never | null;
+                path?: never | null;
+                cookie?: never | null;
+            };
+            requestBody?: never | null;
+            responses: {
+                /** @description 成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Don"][];
+                    };
+                };
+            };
+        };
+        put?: never | null;
+        post?: never | null;
+        delete?: never | null;
+        options?: never | null;
+        head?: never | null;
+        patch?: never | null;
+        trace?: never | null;
+    };
     "/dons/{id}": {
         parameters: {
             query?: never | null;
@@ -43,7 +79,7 @@ interface paths {
                 content: {
                     "application/json": {
                         /** Format: int32 */
-                        status?: number | null;
+                        status: number;
                     };
                 };
             };

--- a/packages/api/openapi.yml
+++ b/packages/api/openapi.yml
@@ -13,24 +13,38 @@ tags:
   - name: order
 
 paths:
+  "/dons":
+    get:
+      tags:
+        - don
+      description: 全ての丼を取得
+      responses:
+        '200':
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Don"
   "/dons/{id}":
     get:
-      tags: 
+      tags:
         - don
       description: 特定のidの丼の詳細を取得
       parameters:
         - name: id
           in: path
           required: true
-          schema: 
+          schema:
             type: integer
             format: int32
       responses:
-        '200': 
+        '200':
           description: 丼の詳細を返す
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: "#/components/schemas/Don"
     put:
       tags:
@@ -40,7 +54,7 @@ paths:
         - name: id
           in: path
           required: true
-          schema: 
+          schema:
             type: integer
             format: int32
       requestBody:
@@ -50,32 +64,32 @@ paths:
             schema:
               type: object
               properties:
-                status: 
+                status:
                   type: integer
                   format: int32
               required:
                 - donId
-                  afterStatus
+                - status
       responses:
-        '201': 
+        '201':
           description: 調理状態の変更に成功
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: "#/components/schemas/Don"
   "/dons/price":
     post:
-      tags: 
+      tags:
         - don
       description: 特定の条件の場合の丼の値段を取得
       requestBody:
         required: true
         content:
           application/json:
-            schema: 
+            schema:
               type: object
               properties:
-                size: 
+                size:
                   type: integer
                   format: int32
                 toppings:
@@ -83,10 +97,10 @@ paths:
                   items:
                     type: object
                     properties:
-                      id: 
+                      id:
                         type: integer
                         format: int32
-                      amount: 
+                      amount:
                         type: integer
                         format: int32
                     required:
@@ -98,18 +112,18 @@ paths:
                 - size
                 - snsFollowed
       responses:
-        '200': 
+        '200':
           description: 価格を返す
           content:
             application/json:
-              schema: 
+              schema:
                 type: object
                 properties:
-                  price: 
+                  price:
                     type: integer
                     format: int32
   "/dons/status/":
-    get: 
+    get:
       tags:
         - don
       description: 特定の状態の丼を取得する
@@ -117,7 +131,7 @@ paths:
         - name: status
           in: path
           required: true
-          schema: 
+          schema:
             type: integer
             format: int32
             description: 調理状態
@@ -134,7 +148,7 @@ paths:
           description: 注文の一覧を正常に取得
           content:
             application/json:
-              schema: 
+              schema:
                 type: array
                 items:
                   $ref: "#/components/schemas/Order"
@@ -147,24 +161,24 @@ paths:
             application/json:
               schema:
                 type: array
-                items: 
+                items:
                   $ref: '#/components/schemas/Option'
   "/order":
     post:
-      tags: 
-        - order 
+      tags:
+        - order
       summary: 新規注文を追加
       description: 新規注文を含むリクエストに対して，DBにその内容を保存し，作成した内容をレスポンスする
       requestBody:
         required: true
         content:
           application/json:
-            schema: 
+            schema:
               type: object
               properties:
                 call_num:
                   type: integer
-                dons: 
+                dons:
                   type: array
                   items:
                     type: object
@@ -184,19 +198,19 @@ paths:
                       abura:
                         type: integer
                         format: int32
-                      snsFollowed: 
+                      snsFollowed:
                         type: boolean
                       toppings:
                         type: array
                         items:
                           type: object
                           properties:
-                            id: 
+                            id:
                               type: integer
                               format: int32
                             label:
                               type: string
-                            amount: 
+                            amount:
                               type: integer
                               format: int32
                           required:
@@ -217,31 +231,31 @@ paths:
           description: 注文の追加が成功
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: "#/components/schemas/Order"
   "/toppings":
     get:
-      tags: 
+      tags:
         - topping
       responses:
         '200':
           description: すべてのトッピングを返す
           content:
             application/json:
-              schema: 
+              schema:
                 type: array
                 items:
                   $ref: "#/components/schemas/Topping"
   "/toppings/available":
     get:
-      tags: 
+      tags:
         - topping
       responses:
         '200':
           description: すべてのトッピングを返す
           content:
             application/json:
-              schema: 
+              schema:
                 type: array
                 items:
                   $ref: "#/components/schemas/Topping"
@@ -267,19 +281,19 @@ components:
         abura:
           type: integer
           format: int32
-        snsFollowed: 
+        snsFollowed:
           type: boolean
         toppings:
           type: array
           items:
             type: object
             properties:
-              id: 
+              id:
                 type: integer
                 format: int32
               label:
                 type: string
-              amount: 
+              amount:
                 type: integer
                 format: int32
             required:
@@ -293,19 +307,19 @@ components:
         - ninniku
         - karame
         - abura
-    Error: 
+    Error:
       type: object
-      properties: 
+      properties:
         title:
           type: string
           description: エラーを簡潔に表現したコード
-        type: 
+        type:
           type: string
           description: エラーの詳細ドキュメントを指すURL
         status:
           type: number
           description: HTTPステータスコード
-        detail: 
+        detail:
           type: string
           description: 開発者向けの詳細文
       required:
@@ -316,9 +330,9 @@ components:
     Option:
       type: object
       properties:
-        id: 
+        id:
           type: integer
-        label: 
+        label:
           type: string
     Order:
       type: object
@@ -342,7 +356,7 @@ components:
     Topping:
       type: object
       properties:
-        id: 
+        id:
           type: integer
           format: int32
         label:
@@ -350,5 +364,5 @@ components:
         price:
           type: integer
           format: int32
-    
+
 

--- a/packages/api/src/gen/schema.ts
+++ b/packages/api/src/gen/schema.ts
@@ -1,4 +1,40 @@
 export interface paths {
+    "/dons": {
+        parameters: {
+            query?: never | null;
+            header?: never | null;
+            path?: never | null;
+            cookie?: never | null;
+        };
+        /** @description 全ての丼を取得 */
+        get: {
+            parameters: {
+                query?: never | null;
+                header?: never | null;
+                path?: never | null;
+                cookie?: never | null;
+            };
+            requestBody?: never | null;
+            responses: {
+                /** @description 成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Don"][];
+                    };
+                };
+            };
+        };
+        put?: never | null;
+        post?: never | null;
+        delete?: never | null;
+        options?: never | null;
+        head?: never | null;
+        patch?: never | null;
+        trace?: never | null;
+    };
     "/dons/{id}": {
         parameters: {
             query?: never | null;
@@ -43,7 +79,7 @@ export interface paths {
                 content: {
                     "application/json": {
                         /** Format: int32 */
-                        status?: number | null;
+                        status: number;
                     };
                 };
             };

--- a/packages/backend/src/routes/dons.ts
+++ b/packages/backend/src/routes/dons.ts
@@ -27,11 +27,11 @@ router.post('/price', typedAsyncWrapper<"/dons/price", "post">(async (req, res) 
     throw ApiError.invalidParams();
   }
 
-  const size = await prisma.sizes.findFirst({ 
-    where: { 
+  const size = await prisma.sizes.findFirst({
+    where: {
       id: reqSize,
-    }, 
-    include: { 
+    },
+    include: {
       size_prices: {
         select: {
           price: true
@@ -70,50 +70,55 @@ router.post('/price', typedAsyncWrapper<"/dons/price", "post">(async (req, res) 
     return sum + price * amount;
   }, 0);
 
-  const discount = isFollowed 
+  const discount = isFollowed
   ? -1 * toppingsPrices.reduce((lowestPrice, topping) => {
       const price = topping.topping_prices[0].price;
       if (lowestPrice < price) {
         return price;
-      } 
+      }
       else {
         return lowestPrice;
       }
     }, 0)
   : 0;
-  
+
   const price = donPrice + toppingsPrice + discount;
 
   res.status(200).send({ price });
 }));
 
-//GetDonByID
-//IDが指定されなかった場合，エラーメッセージを返す．
-router.get('/', asyncWrapper(async (req, res, next) => {
-  throw ApiError.invalidParams;
+
+router.get('/', typedAsyncWrapper<"/dons", "get">(async (req, res, next) => {
+  const dons = await prisma.dons.findMany();
+
+  const resDons = dons.map(don => ({
+    ...don,
+    id: bigint2number(don.id),
+    size: don.size_id,
+    order_id: bigint2number(don.order_id)
+  }));
+
+  res.status(200).json(resDons);
 
 }));
 
-//あるIDのDonの詳細を返す
-router.get('/:id', typedAsyncWrapper<"/dons/{id}", "get">(async (req, res, next) => {
 
-  //クエリパラメータを取得．
+router.get('/:id', typedAsyncWrapper<"/dons/{id}", "get">(async (req, res, next) => {
   const id = req.params.id;
 
-  //idが非負の整数に変換できるデータか，正規表現で検証する
+  // idが非負の整数に変換できるデータか，正規表現で検証する
   if( !/^\d+$/.test(`${id}`) ){
     throw ApiError.invalidParams();
   }
 
-  
-  //そのIDのDonを取得する
+  // そのIDのDonを取得する
   const don = await prisma.dons.findUnique({
     where: {
       id: Number(id),
     },
   });
 
-  //そのIDのDonがない場合，エラーを返す．
+  // そのIDのDonがない場合，エラーを返す．
   if(!don){
     throw ApiError.internalProblems();
   }
@@ -125,10 +130,42 @@ router.get('/:id', typedAsyncWrapper<"/dons/{id}", "get">(async (req, res, next)
     order_id: bigint2number(don.order_id)
   };
 
-  //とりあえずJSONで送る
+  // とりあえずJSONで送る
   res.status(200).json(resDon);
 
 }));
 
+router.put('/:id', typedAsyncWrapper<"/dons/{id}", "put">(async (req, res, next) => {
+  const id = req.params.id;
+  const status = req.body.status;
+
+  if (status != 1 && status != 2) {
+    if (status != 3) {
+      throw ApiError.invalidParams('You can only update status to 1, 2.');
+    }
+    if (status == 3) {
+      throw ApiError.invalidParams('Status 3 cannot be updated.');
+    }
+  }
+
+  const nextStatus = status + 1;
+
+  const updatedDon = await prisma.dons.update({
+    where: {
+      id: id,
+    },
+    data: {
+      status: nextStatus,
+    },
+  })
+
+  const response = {
+    ...updatedDon,
+    id: bigint2number(updatedDon.id),
+    size: updatedDon.size_id,
+  }
+
+  res.status(200).json(response);
+}));
 
 export default router;


### PR DESCRIPTION
close #16 

## やったこと
- `put dons/id`追加
  - APIスキーマの`nextStatus`を`status`に直し忘れていた箇所1か所も修正
-  `get /dons`の修正
  -  エラー返すようになっていたが、全取得に変更 合わせてAPIスキーマにも追加

## 備考
自分の開発環境の関係で自動で不要なスペースを削除していて、ファイル末尾に改行を追加されていますmm。
GitHub上で差分を見るときは Hide whitespace の設定をした方が見やすいかもです

## 注意事項
prisma のスキーマの`adding`まわり処理がどうなっているかちょっと謎な気がしました。
これから調査する予定ですが、toppingの情報を載せれていない気がする。（一旦後回しでよさそう）