### PR TITLE
オプションの量と対応する数値の辞書を取得するAPIの実装

### DIFF
--- a/packages/api/dist/schema.d.mts
+++ b/packages/api/dist/schema.d.mts
@@ -366,8 +366,8 @@ interface components {
             detail: string;
         };
         Option: {
-            id?: number | null;
-            label?: string | null;
+            id: number;
+            label: string;
         };
         Order: {
             /** Format: int32 */

--- a/packages/api/dist/schema.d.ts
+++ b/packages/api/dist/schema.d.ts
@@ -366,8 +366,8 @@ interface components {
             detail: string;
         };
         Option: {
-            id?: number | null;
-            label?: string | null;
+            id: number;
+            label: string;
         };
         Order: {
             /** Format: int32 */

--- a/packages/api/openapi.yml
+++ b/packages/api/openapi.yml
@@ -320,6 +320,9 @@ components:
           type: integer
         label: 
           type: string
+      required:
+        - id
+        - label
     Order:
       type: object
       properties:

--- a/packages/api/src/gen/schema.ts
+++ b/packages/api/src/gen/schema.ts
@@ -366,8 +366,8 @@ export interface components {
             detail: string;
         };
         Option: {
-            id?: number | null;
-            label?: string | null;
+            id: number;
+            label: string;
         };
         Order: {
             /** Format: int32 */

--- a/packages/backend/prisma/migrations/20241026145444_add_table_option/migration.sql
+++ b/packages/backend/prisma/migrations/20241026145444_add_table_option/migration.sql
@@ -1,0 +1,7 @@
+-- CreateTable
+CREATE TABLE "options" (
+    "id" BIGSERIAL NOT NULL,
+    "label" VARCHAR(255) NOT NULL,
+
+    CONSTRAINT "options_pkey" PRIMARY KEY ("id")
+);

--- a/packages/backend/prisma/migrations/20241026150052_change_type_options_id/migration.sql
+++ b/packages/backend/prisma/migrations/20241026150052_change_type_options_id/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - The primary key for the `options` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to alter the column `id` on the `options` table. The data in that column could be lost. The data in that column will be cast from `BigInt` to `Integer`.
+
+*/
+-- AlterTable
+ALTER TABLE "options" DROP CONSTRAINT "options_pkey",
+ALTER COLUMN "id" SET DATA TYPE Integer,
+ADD CONSTRAINT "options_pkey" PRIMARY KEY ("id");

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -47,6 +47,11 @@ model orders {
   dons       dons[]
 }
 
+model options {
+  id    Int    @id @default(autoincrement())
+  label String @db.VarChar(255)
+}
+
 model sizes {
   id          Int           @id @default(autoincrement())
   label       String        @db.VarChar(255)

--- a/packages/backend/src/routes/options.ts
+++ b/packages/backend/src/routes/options.ts
@@ -1,0 +1,11 @@
+import { typedAsyncWrapper } from '@/utils/wrappers';
+import express from 'express';
+import prisma from '@/lib/prismaClient';
+
+const router = express.Router();
+
+router.get('/', typedAsyncWrapper<"/options", "get">(async (req, res) => {
+  const options = await prisma.options.findMany();
+
+  res.send(options);
+}));


### PR DESCRIPTION
Fixes #17

### やったこと
- API`/options`を追加
- DBに`options`テーブルを追加
- openapi schemaで`require`がついていない問題を修正