### PR TITLE
Add backend unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "env-cmd": "^10.1.0",
     "react-spring": "^9.7.4",
     "react-swipeable": "^7.0.1"
+  },
+  "devDependencies": {
+    "react-is": "^19.1.0"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node ./built/index.js",
     "build": "tsc -p tsconfig.json && tsc-alias -p tsconfig.json",
     "watch": "tsc-watch --noClear --onSuccess \"node watch.mjs\"",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
     "migrate:create": "npx prisma migrate dev --create-only",
     "migrate:exe": "npx prisma migrate dev",
     "migrate:status": "npx prisma migrate status",
@@ -28,6 +28,7 @@
     "@types/node": "^20.11.20",
     "prisma": "^5.11.0",
     "tsc-alias": "^1.8.8",
-    "tsc-watch": "^6.0.4"
+    "tsc-watch": "^6.0.4",
+    "vitest": "^1.6.1"
   }
 }

--- a/packages/backend/src/utils/__tests__/ApiError.test.ts
+++ b/packages/backend/src/utils/__tests__/ApiError.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { ApiError } from '../ApiError';
+
+describe('ApiError', () => {
+  it('has default internal error when no schema provided', () => {
+    const err = new ApiError();
+    expect(err.title).toBe('INTERNAL_PROBLEMS');
+    expect(err.status).toBe(500);
+  });
+
+  it('invalidParams returns ApiError with 400 status', () => {
+    const err = ApiError.invalidParams('invalid');
+    expect(err.title).toBe('INVAILD_PARAMS');
+    expect(err.status).toBe(400);
+    expect(err.detail).toBe('invalid');
+  });
+});

--- a/packages/backend/src/utils/__tests__/typeConverters.test.ts
+++ b/packages/backend/src/utils/__tests__/typeConverters.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { bigint2number } from '../typeConverters';
+
+describe('bigint2number', () => {
+  it('converts bigint within safe range to number', () => {
+    const value = BigInt(123);
+    expect(bigint2number(value)).toBe(123);
+  });
+
+  it('throws error when bigint exceeds safe range', () => {
+    const big = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1);
+    expect(() => bigint2number(big)).toThrow('BigIntの値がNumberの安全な範囲を超えています');
+  });
+});

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add vitest configuration to backend
- install vitest and react-is for testing
- add test script to backend package.json
- create unit tests for bigint2number and ApiError

## Testing
- `npm test -w packages/backend`

------
https://chatgpt.com/codex/tasks/task_e_6841205d78a08329b5bffbf4338cb9d5