### PR TITLE
Add unit test for bigint2number

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "migrate:dev": "pnpm run migrate:exe",
     "migrate:status": "env-cmd -f .env pnpm --filter backend run migrate:status",
     "migrate:reset": "env-cmd -f .env pnpm --filter backend run migrate:reset",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "pnpm exec tsx --test"
   },
   "author": "",
   "license": "ISC",
@@ -32,7 +32,8 @@
     "react-swipeable": "^7.0.2"
   },
   "devDependencies": {
-    "prettier": "^3.5.3"
+    "prettier": "^3.5.3",
+    "tsx": "^4.9.0"
   },
   "packageManager": "pnpm@10.11.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
+      tsx:
+        specifier: ^4.9.0
+        version: 4.19.4
 
   packages/api:
     devDependencies:

--- a/tests/typeConverters.test.ts
+++ b/tests/typeConverters.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { bigint2number } from '../packages/backend/src/utils/typeConverters';
+
+test('bigint2number returns number within safe range', () => {
+  const result = bigint2number(123n);
+  assert.strictEqual(result, 123);
+});
+
+test('bigint2number throws when value exceeds safe range', () => {
+  const value = BigInt(Number.MAX_SAFE_INTEGER) + 1n;
+  assert.throws(() => bigint2number(value));
+});


### PR DESCRIPTION
## Summary
- add a unit test for `bigint2number`
- install `tsx` and configure `pnpm test` script

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d66f3bb083248d6a35237a7032e2