### PR TITLE
donの状態遷移図を追加

### DIFF
--- a/docs/don-state.md
+++ b/docs/don-state.md
@@ -4,11 +4,11 @@
 stateDiagram-v2
     [*] --> Ordered
     Ordered --> Cooking
-    Cooking --> Calling
-    Calling --> Finished
+    Cooking --> Cooked
+    Cooked --> Delivered
     Ordered --> Cancelled
     Cooking --> Cancelled
     Calling --> Cancelled
     Cancelled --> [*]
-    Finished --> [*]
+    Delivered --> [*]
 ```

--- a/docs/don-state.md
+++ b/docs/don-state.md
@@ -8,7 +8,7 @@ stateDiagram-v2
     Cooked --> Delivered
     Ordered --> Cancelled
     Cooking --> Cancelled
-    Calling --> Cancelled
+    Cooked --> Cancelled
     Cancelled --> [*]
     Delivered --> [*]
 ```

--- a/docs/don-state.md
+++ b/docs/don-state.md
@@ -1,0 +1,14 @@
+# don状態遷移図
+
+```mermaid
+stateDiagram-v2
+    [*] --> Ordered
+    Ordered --> Cooking
+    Cooking --> Calling
+    Calling --> Finished
+    Ordered --> Cancelled
+    Cooking --> Cancelled
+    Calling --> Cancelled
+    Cancelled --> [*]
+    Finished --> [*]
+```


### PR DESCRIPTION
```mermaid
stateDiagram-v2
    [*] --> Ordered
    Ordered --> Cooking
    Cooking --> Cooked
    Cooked --> Delivered
    Ordered --> Cancelled
    Cooking --> Cancelled
    Cooked --> Cancelled
    Cancelled --> [*]
    Delivered --> [*]
```

おそらく注文時に決済までするので、そういう意味でキャンセルは不要かも。

ただしトッピングの変更時には、一度キャンセルして新規にdonを追加、という形にした方が動的プロパティが少なくて良いかも。

あとER図見てて思ったけどtoppingとsizeって概念的に同じでは。（統合して統一的に処理できそう）
