### PR TITLE
ciでdockerのビルドキャッシュを使わない

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,5 @@
+## dockerのビルドキャッシュについて
+
+Github Actions キャッシュへのdockerのビルドキャッシュの追加は一度試みましたが、キャッシュエクスポートに4分近くかかってしまって全然ビルド時間削減できなかったので諦めました。
+
+例：https://github.com/ARCircle/Kojirer/actions/runs/17031807940/job/48276086610

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -50,5 +50,3 @@ jobs:
           tags: ${{ steps.meta.outputs.FULL_IMAGE }}
           target: production
           platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,8 +47,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.FULL_IMAGE }}
           target: production
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           platforms: linux/amd64
 
       - uses: imranismail/setup-kustomize@v1


### PR DESCRIPTION
キャッシュのエクスポート時間の方がビルド時間よりも長くて意味なさすぎたのでやめました