### PR TITLE
cleaning時にtsbuildinfoも消す

### DIFF
--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -8,4 +8,4 @@ const __dirname = path.dirname(__filename);
 fs.rmSync(__dirname + '/../packages/backend/built', { recursive: true, force: true });
 fs.rmSync(__dirname + '/../packages/frontend/built', { recursive: true, force: true });
 
-fs.rmSync(__dirname + '/../packages/backend/tsconfig.tsbuildinfo');
+fs.rmSync(__dirname + '/../packages/backend/tsconfig.tsbuildinfo', { force: true });

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -7,3 +7,5 @@ const __dirname = path.dirname(__filename);
 
 fs.rmSync(__dirname + '/../packages/backend/built', { recursive: true, force: true });
 fs.rmSync(__dirname + '/../packages/frontend/built', { recursive: true, force: true });
+
+fs.rmSync(__dirname + '/../packages/backend/tsconfig.tsbuildinfo');


### PR DESCRIPTION
タイトル通り。
tsbuildinfoにはビルド済みモジュールの情報が含まれているのでビルド成果物をクリーニングにより削除した場合こっちも消す必要がある（そうしないと次回のビルドでビルドされないモジュールが出てくる）