### PR TITLE
ビルド時にテストファイルをコンパイルしないようにする

### DIFF
--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -31,5 +31,6 @@
     /* Completeness */
     "skipLibCheck": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**/*"]
 }


### PR DESCRIPTION
ビルド成果物にtest.tsが生えていてローカルでテストが落ちていたので対応

tsconfigを書き換えたのでbuilt/とtsbuildinfoを一度消す必要があるかもしれません